### PR TITLE
Fix renewal email subject line

### DIFF
--- a/ownership/messages/ca_R1_subject.txt
+++ b/ownership/messages/ca_R1_subject.txt
@@ -1,1 +1,1 @@
-"Your Momentum membership is expiring soon!"
+"Your Momentum membership will renew next week"


### PR DESCRIPTION
Forgot one edit in the last update. This new subject line is less urgent-sounding and more appropriate to auto-renewal.