### PR TITLE
Change renewal to expiration

### DIFF
--- a/ownership/messages/ca_R1_subject.txt
+++ b/ownership/messages/ca_R1_subject.txt
@@ -1,1 +1,1 @@
-"Your Momentum membership will renew next week"
+"Your Momentum membership will expire next week"


### PR DESCRIPTION
Email subject line is misleading, implies automatic renewal is still on. Change from "renew" to "expire".